### PR TITLE
fix: replace deprecated API for analysis and diff files

### DIFF
--- a/pkg/tar-diff/analysis.go
+++ b/pkg/tar-diff/analysis.go
@@ -5,7 +5,6 @@ import (
 	"crypto/sha1"
 	"encoding/hex"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -324,7 +323,7 @@ func analyzeForDelta(old *tarInfo, new *tarInfo, oldFile io.Reader) (*deltaAnaly
 		targetInfoByIndex[t.file.index] = t
 	}
 
-	tmpfile, err := ioutil.TempFile("/var/tmp", "tar-diff-")
+	tmpfile, err := os.CreateTemp("/var/tmp", "tar-diff-")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tar-diff/diff.go
+++ b/pkg/tar-diff/diff.go
@@ -8,7 +8,6 @@ import (
 	"archive/tar"
 	"bytes"
 	"io"
-	"io/ioutil"
 
 	"github.com/containers/image/v5/pkg/compression"
 )
@@ -33,7 +32,7 @@ func (g *deltaGenerator) setSkip(ignore bool) {
 // Skip the rest of the current file from the tarfile
 func (g *deltaGenerator) skipRest() error {
 	g.setSkip(true)
-	_, err := io.Copy(ioutil.Discard, g.tarReader)
+	_, err := io.Copy(io.Discard, g.tarReader)
 	return err
 }
 
@@ -48,14 +47,14 @@ func (g *deltaGenerator) readN(n int64) ([]byte, error) {
 // Copy the rest of the current file from the tarfile into the delta
 func (g *deltaGenerator) copyRest() error {
 	g.setSkip(false)
-	_, err := io.Copy(ioutil.Discard, g.tarReader)
+	_, err := io.Copy(io.Discard, g.tarReader)
 	return err
 }
 
 // Copy the next n bytes of the current file from the tarfile into the delta
 func (g *deltaGenerator) copyN(n int64) error {
 	g.setSkip(false)
-	_, err := io.CopyN(ioutil.Discard, g.tarReader, int64(n))
+	_, err := io.CopyN(io.Discard, g.tarReader, int64(n))
 	return err
 }
 
@@ -232,7 +231,7 @@ func generateDelta(newFile io.ReadSeeker, deltaFile io.Writer, analysis *deltaAn
 		}
 	}
 	// Steal any remaining data left by tar reader
-	if _, err := io.Copy(ioutil.Discard, stealingTarFile); err != nil {
+	if _, err := io.Copy(io.Discard, stealingTarFile); err != nil {
 		return err
 	}
 	// Flush any outstanding stolen data


### PR DESCRIPTION
Replaces deprecated API in analysis.go and diff.go to use either io or os import.