### PR TITLE
Update Makefile: Ensure make install respects DESTDIR and PREFIX, and Add `make dist` target for source tarball creation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,8 @@ jobs:
         run: |
           dnf update -y
           dnf install -y golang make tar diffutils bzip2 gzip curl git which
+      - name: Mark repo as safe for git
+        run: git config --global --add safe.directory $GITHUB_WORKSPACE
       - name: Check out repository
         uses: actions/checkout@v6
       - name: Build and test

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,8 @@
-.PHONY: all build clean fmt install lint test tools unit-test integration-test validate .install.golangci-lint
+PROJECT := tar-diff
+VERSION := $(shell grep -oP 'VERSION\s*=\s*"\K[^"]+' pkg/common/version.go)
+PROJ_TARBALL := $(PROJECT)_$(VERSION).tar.gz
+
+.PHONY: all build clean fmt install lint test tools dist unit-test integration-test validate .install.golangci-lint
 
 export GOPROXY=https://proxy.golang.org
 
@@ -24,6 +28,9 @@ export PATH := $(PATH):${GOBIN}
 
 all: tools tar-diff tar-patch test validate
 
+$(PROJ_TARBALL):
+	git archive --prefix=tar-diff_$(VERSION)/ --format=tar.gz HEAD --output $(PROJ_TARBALL) 
+
 build:
 	go build $(GOFLAGS) ./...
 
@@ -47,6 +54,7 @@ tools: .install.golangci-lint
 
 clean:
 	rm -f tar-diff tar-patch
+	rm -rf $(PROJECT)_$(VERSION) $(PROJ_TARBALL)
 
 integration-test: tar-diff tar-patch
 	tests/test.sh
@@ -65,3 +73,7 @@ validate: lint
 
 lint:
 	GOFLAGS=$(GOFLAGS) $(GOBIN)/golangci-lint run
+
+dist: $(PROJ_TARBALL)
+	@echo "Created $(PROJ_TARBALL)"
+


### PR DESCRIPTION

1. PREFIX and DESTDIR paths in the makefile are separated for clear installation logic.
- PREFIX is the target prefix, while DESTDIR can be optionally used for staging, in the install directory.

2. Creates a `make dist`  target that produces a distributable source tarball. This is needed for Fedora/RPM packaging workflows where source tarballs are the standard input format