### PR TITLE
Don't use delta for tiny files

### DIFF
--- a/pkg/tar-diff/diff.go
+++ b/pkg/tar-diff/diff.go
@@ -158,6 +158,13 @@ func (g *deltaGenerator) generateForFile(info *targetInfo) error {
 
 	maxBsdiffSize := g.options.maxBsdiffSize
 
+	// For files that are smaller than the path to the delta source plus some small
+	// space for the delta header, skip doing deltas, as delta data will be larger
+	// than the content.
+	if file.size <= int64(len(sourceFile.paths[0])+4) {
+		return nil
+	}
+
 	switch {
 	case sourceFile.sha1 == file.sha1 && sourceFile.size == file.size:
 		// Reuse exact file from old tar


### PR DESCRIPTION
Files that are smaller than the pathname of the delta source (and some extra header bytes) now are copied directly to the delta rather than being delta:ed, because just the delta header would already be larger than the file content.

This happens a lot in e.g. bootc images, because there are lots of tiny ostree metadata objects that have long pathnames, like the *.file-xattrs-link files that are 46 bytes, but have 110 char long pathnames.