### PR TITLE
feat: Add CI optimizations and README badges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   test-makefile:
@@ -17,6 +21,7 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version: "1.25"
+          cache: true
       - name: Install dependencies
         run: |
           sudo apt-get update
@@ -56,7 +61,7 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - name: Github app installation token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@v4
         id: app-token
         with:
           app-id: ${{ vars.RELEASE_APP_ID }}
@@ -103,6 +108,7 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version: "1.25"
+          cache: true
       - name: Install dependencies
         run: |
           choco install -y make diffutils gzip bzip2 git

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![CI](https://github.com/containers/tar-diff/actions/workflows/ci.yml/badge.svg)](https://github.com/containers/tar-diff/actions/workflows/ci.yml)
+[![Go Version](https://img.shields.io/badge/go-1.25-blue.svg)](https://golang.org/dl/)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![codecov](https://codecov.io/gh/containers/tar-diff/graph/badge.svg)](https://codecov.io/gh/containers/tar-diff)
 
 # tar-diff


### PR DESCRIPTION
  - Add concurrency groups to cancel outdated workflow runs
  - Enable Go module caching for faster builds
  - Update actions/create-github-app-token to v4
  - Add CI status, Go version, and license badges to README

  Addresses #30