### PR TITLE
fix: rollback create-github-app-token to v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - name: Github app installation token
-        uses: actions/create-github-app-token@v4
+        uses: actions/create-github-app-token@v3
         id: app-token
         with:
           app-id: ${{ vars.RELEASE_APP_ID }}


### PR DESCRIPTION
The create-github-app-token was mistakenly updated to v4 in the last PR, creating a job failure. This pr rolls it back to v3.