### PR TITLE
fix: remove '@semantic-release/exec plugin' (avoids extra npm install)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,9 @@
 name: Release
 
 on:
-  workflow_dispatch:  # Triggered by semantic-release via gh CLI
+  release:
+    types: [published]
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -5,6 +5,3 @@ plugins:
   - "@semantic-release/commit-analyzer"
   - "@semantic-release/release-notes-generator"
   - "@semantic-release/github"
-  - ["@semantic-release/exec", {
-      "publishCmd": "gh workflow run release.yml"
-    }]


### PR DESCRIPTION
This PR removes @semantic-release/exec plugin removing the need for a package.json file which would include npm dependencies that the project doesn't otherwise use.

release.yml now runs on `release: published` instead of `gh workflow run` trigger from @semantic-release/exec.