### PR TITLE
ci: upgrades go version to latest stable version to resolve security vulnerability bug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  GOTOOLCHAIN: auto
 jobs:
-
   test-makefile:
     name: Build and test makefile
     runs-on: ubuntu-latest
@@ -20,7 +21,8 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: 'stable'
+          check-latest: true
           cache: true
       - name: Install dependencies
         run: |
@@ -46,10 +48,16 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
+      - name: Set up GO
+        uses: actions/setup-go@v6
+        with:
+          go-version: 'stable'
+          check-latest: true
+          cache: true
       - name: Install dependencies
         run: |
           dnf update -y
-          dnf install -y golang make tar diffutils bzip2 gzip curl git which
+          dnf install -y make tar diffutils bzip2 gzip curl git which
       - name: Mark repo as safe for git
         run: git config --global --add safe.directory $GITHUB_WORKSPACE
       - name: Build and test
@@ -107,7 +115,8 @@ jobs:
         uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: 'stable'
+          check-latest: true
           cache: true
       - name: Install dependencies
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,8 @@ on:
 
 permissions:
   contents: write
-
+env:
+  GOTOOLCHAIN: auto
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
@@ -18,9 +19,10 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
-          go-version: '1.26.1'
+          go-version: 'stable'
+          check-latest: true
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -7,7 +7,8 @@ on:
     branches: [ main ]
   schedule:
     - cron: '0 6 * * *'
-
+env:
+  GOTOOLCHAIN: auto
 jobs:
   vulnerability-scan:
     name: Vulnerability Scanning
@@ -19,7 +20,8 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.25'
+        go-version: 'stable'
+        check-latest: true
 
     - name: Install govulncheck
       run: go install golang.org/x/vuln/cmd/govulncheck@latest
@@ -47,7 +49,8 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.25'
+        go-version: 'stable'
+        check-latest: true
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v4

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/containers/tar-diff
 
-go 1.25
+go 1.26
+
+toolchain go1.26.2
 
 require (
 	github.com/containers/image/v5 v5.36.2


### PR DESCRIPTION
This PR fixes [security vulnerability bug](https://pkg.go.dev/vuln/GO-2026-4869) causing CI failure