### PR TITLE
test: replace tar alias with shell function for macOS compatibility

### DIFF
--- a/tests/test-multi-old.sh
+++ b/tests/test-multi-old.sh
@@ -47,8 +47,8 @@ modify_orig "$TEST_DIR/modified" "$TEST_DIR/orig.tar"
 create_tar "$TEST_DIR/modified.tar" "$TEST_DIR/modified"
 
 # old1: full tree minus every peeled file
-cp -dR --no-preserve=context "$TEST_DIR/orig" "$TEST_DIR/mo-base" 2>/dev/null \
-	|| cp -dR "$TEST_DIR/orig" "$TEST_DIR/mo-base"
+cp -RP --no-preserve=context "$TEST_DIR/orig" "$TEST_DIR/mo-base" 2>/dev/null \
+	|| cp -RP "$TEST_DIR/orig" "$TEST_DIR/mo-base"
 for rel in "${PEEL[@]}"; do
 	rm -f "$TEST_DIR/mo-base/data/$rel"
 done

--- a/tests/utils.sh
+++ b/tests/utils.sh
@@ -5,8 +5,8 @@
 
 use_gnu_tar_if_available() {
     if command -v gtar &>/dev/null; then
-        shopt -s expand_aliases
-        alias tar=gtar
+        tar() { gtar "$@"; }
+        export -f tar
     fi
     return 0
 }


### PR DESCRIPTION
With the `tar` alias failing on previous macOS runs, this PR replaces it with the `tar()` shell function defined in `use_gnu_tar_if_available()` which uses `gtar` instead of `tar` if available.

The previous `alias tar=gtar` did not propagate inside the create_tar() function, causing it to use BSD tar instead of the required GNU tar.

Closes #83 